### PR TITLE
fix(#55): implement user data isolation to prevent cross-user data access

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,7 @@
 import 'vite-plugin-pwa/svelte';
 import 'vite-plugin-pwa/info';
 import 'vite-plugin-pwa/pwa-assets';
+import { SupabaseClient, Session, User } from '@supabase/supabase-js';
 
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
@@ -11,12 +12,16 @@ declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
+			supabase: SupabaseClient;
+			safeGetSession(): Promise<{ session: Session | null; user: User | null }>;
 			userid: string;
 			buildDate: string;
 			periodicUpdates: boolean;
 		}
 
-		// interface PageData {}
+		interface PageData {
+			session: Session | null;
+		}
 		// interface PageState {}
 		// interface Platform {}
 	}

--- a/src/lib/repositories/CatchRecordRepository.ts
+++ b/src/lib/repositories/CatchRecordRepository.ts
@@ -9,6 +9,10 @@ class CatchRecordRepository {
 		return CatchRecordModel.find().exec();
 	}
 
+	async findByUserId(userId: string): Promise<CatchRecord[]> {
+		return CatchRecordModel.find({ userId }).exec();
+	}
+
 	async create(data: Partial<CatchRecord>): Promise<CatchRecord> {
 		return CatchRecordModel.create(data);
 	}

--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -1,0 +1,29 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
+
+/**
+ * Validates the user session and returns the authenticated user ID
+ * Throws a 401 error if the user is not authenticated
+ */
+export async function requireAuth(event: RequestEvent): Promise<string> {
+	const { session, user } = await event.locals.safeGetSession();
+	
+	if (!session || !user) {
+		throw error(401, 'Authentication required');
+	}
+	
+	return user.id;
+}
+
+/**
+ * Optionally validates the user session and returns the user ID if authenticated
+ * Returns null if not authenticated (no error thrown)
+ */
+export async function getOptionalUserId(event: RequestEvent): Promise<string | null> {
+	try {
+		const { session, user } = await event.locals.safeGetSession();
+		return user?.id || null;
+	} catch {
+		return null;
+	}
+}

--- a/src/routes/api/catch-records/+server.ts
+++ b/src/routes/api/catch-records/+server.ts
@@ -1,19 +1,27 @@
-import { json } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
 import { dbConnect, dbDisconnect } from '$lib/utils/db';
 import { type CatchRecord } from '$lib/models/CatchRecord';
 import CatchRecordRepository from '$lib/repositories/CatchRecordRepository';
+import { requireAuth } from '$lib/utils/auth';
+import type { RequestEvent } from '@sveltejs/kit';
 
-export const GET = async () => {
+export const GET = async (event: RequestEvent) => {
 	let catchData = null as CatchRecord[] | null;
 
 	try {
+		const userId = await requireAuth(event);
 		await dbConnect();
 		const repo = new CatchRecordRepository();
-		catchData = await repo.findAll();
+		catchData = await repo.findByUserId(userId);
 		// order by pokedexEntryId property, ascending
 		catchData = catchData.sort((a, b) => a.pokedexEntryId - b.pokedexEntryId);
 	} catch (error) {
 		console.error(error);
+		if (error.status) {
+			// Re-throw SvelteKit errors (like 401)
+			throw error;
+		}
+		return json({ error: 'Internal Server Error' }, { status: 500 });
 	} finally {
 		dbDisconnect();
 	}
@@ -21,29 +29,40 @@ export const GET = async () => {
 	return json(catchData);
 };
 
-export const PUT = async ({ request }) => {
+export const PUT = async (event: RequestEvent) => {
 	try {
-		const data: Partial<CatchRecord> = await request.json();
+		const userId = await requireAuth(event);
+		const data: Partial<CatchRecord> = await event.request.json();
+		
+		// Ensure the userId is set to the authenticated user
+		data.userId = userId;
+		
 		await dbConnect();
 		const repo = new CatchRecordRepository();
 		const upsertedRecord = await repo.upsert(data);
 		return json(upsertedRecord);
 	} catch (err) {
 		console.error(err);
-		throw error(500, 'Internal Server Error');
+		if (err.status) {
+			throw err;
+		}
+		return json({ error: 'Internal Server Error' }, { status: 500 });
 	} finally {
 		await dbDisconnect();
 	}
 };
 
-export const POST = async ({ request }) => {
+export const POST = async (event: RequestEvent) => {
 	try {
-		const records: Partial<CatchRecord>[] = await request.json();
+		const userId = await requireAuth(event);
+		const records: Partial<CatchRecord>[] = await event.request.json();
 		await dbConnect();
 		const repo = new CatchRecordRepository();
 
 		const insertedRecords = [];
 		for (const record of records) {
+			// Ensure the userId is set to the authenticated user
+			record.userId = userId;
 			const upsertedRecord = await repo.upsert(record);
 			insertedRecords.push(upsertedRecord);
 		}
@@ -51,7 +70,10 @@ export const POST = async ({ request }) => {
 		return json(insertedRecords);
 	} catch (err) {
 		console.error(err);
-		throw error(500, 'Internal Server Error');
+		if (err.status) {
+			throw err;
+		}
+		return json({ error: 'Internal Server Error' }, { status: 500 });
 	} finally {
 		await dbDisconnect();
 	}

--- a/src/routes/api/combined-data/all/+server.ts
+++ b/src/routes/api/combined-data/all/+server.ts
@@ -1,23 +1,28 @@
 import { json } from '@sveltejs/kit';
 import { dbConnect, dbDisconnect } from '$lib/utils/db';
 import CombinedDataRepository from '$lib/repositories/CombinedDataRepository';
+import { requireAuth } from '$lib/utils/auth';
+import type { RequestEvent } from '@sveltejs/kit';
 
-export const GET = async ({ url }) => {
+export const GET = async (event: RequestEvent) => {
+	const { url } = event;
 	const enableForms = url.searchParams.get('enableForms') === 'true';
 	const region = url.searchParams.get('region');
 	const game = url.searchParams.get('game');
 
 	try {
+		const userId = await requireAuth(event);
 		await dbConnect();
 		const repo = new CombinedDataRepository();
-		const combinedData = await repo.findAllCombinedData(enableForms, region, game);
+		const combinedData = await repo.findAllCombinedData(userId, enableForms, region, game);
 
-		if (combinedData.length === 0) {
-			return json({ error: 'No combined data found' }, { status: 404 });
-		}
+		// Return empty array instead of 404 for better UX
 		return json(combinedData);
 	} catch (error) {
 		console.error(error);
+		if (error.status) {
+			throw error;
+		}
 		return json({ error: 'Internal Server Error' }, { status: 500 });
 	} finally {
 		dbDisconnect();


### PR DESCRIPTION
- Add server-side authentication validation for all protected API endpoints
- Create auth utility with requireAuth() function for session validation
- Update CombinedDataRepository to filter data by authenticated user ID
- Add findByUserId() method to CatchRecordRepository for user-specific queries
- Replace client-side userId parameters with server-side session extraction
- Use MongoDB aggregation with $lookup and $expr for secure user filtering
- Return 401 errors for unauthenticated requests
- Fix critical security vulnerability where users could see others' catch records

Fixes: User data isolation bug where one user's catch records were used for everyone
Security: Prevents unauthorized access to other users' Pokemon tracking data

🤖 Generated with [Claude Code](https://claude.ai/code)