### PR TITLE
feat(#57): Replace 'mark box as' buttons with dropdown for better ux

### DIFF
--- a/src/lib/components/pokedex/PokedexViewBoxes.svelte
+++ b/src/lib/components/pokedex/PokedexViewBoxes.svelte
@@ -346,6 +346,7 @@
 					style="--boxes-per-row: {boxesPerRow}; --cell-padding: {cellPaddingRem}rem; --sprite-size: {spriteSizePx}px;"
 				>
 					{#each boxNumbers as boxNumber}
+						{@const bulkMenuId = `box-${boxNumber}-bulk-menu`}
 						<div class="mb-8">
 							<div class="flex flex-wrap items-center justify-between gap-3 mb-4 relative z-20">
 								<h2 class="text-xl font-bold">Box {boxNumber}</h2>
@@ -355,6 +356,7 @@
 										class="btn btn-sm btn-outline relative z-[210]"
 										aria-label="Open bulk actions menu"
 										aria-haspopup="menu"
+										aria-controls={bulkMenuId}
 										aria-expanded={openBulkMenuForBox === boxNumber}
 										on:click={(event) => {
 											event.stopPropagation();
@@ -369,12 +371,13 @@
 
 									{#if openBulkMenuForBox === boxNumber}
 										<ul
+											id={bulkMenuId}
 											class="menu bg-base-100 rounded-box absolute right-0 mt-2 z-[220] w-56 p-2 shadow border border-base-300"
-											role="menu"
 											on:click|stopPropagation
 										>
 											<li>
 												<button
+													type="button"
 													on:click={() => {
 														markBoxAsNotCaught(boxNumber);
 														openBulkMenuForBox = null;
@@ -385,6 +388,7 @@
 											</li>
 											<li>
 												<button
+													type="button"
 													on:click={() => {
 														markBoxAsCaught(boxNumber);
 														openBulkMenuForBox = null;
@@ -395,6 +399,7 @@
 											</li>
 											<li>
 												<button
+													type="button"
 													on:click={() => {
 														markBoxAsNeedsToEvolve(boxNumber);
 														openBulkMenuForBox = null;
@@ -405,6 +410,7 @@
 											</li>
 											<li>
 												<button
+													type="button"
 													on:click={() => {
 														markBoxAsInHome(boxNumber);
 														openBulkMenuForBox = null;
@@ -415,6 +421,7 @@
 											</li>
 											<li>
 												<button
+													type="button"
 													on:click={() => {
 														markBoxAsNotInHome(boxNumber);
 														openBulkMenuForBox = null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pokédex boxes now use a single consolidated dropdown per box for bulk actions, replacing multiple individual buttons.
  * Menus close automatically when pressing Escape or clicking outside.

* **Improvements**
  * Improved accessibility with ARIA attributes to reflect and control menu state.
  * Only one dropdown menu opens at a time for clearer focus and interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->